### PR TITLE
Taxi Update

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -2,6 +2,10 @@ local QBCore = exports['qb-core']:GetCoreObject()
 local config = Config
 local ordered = nil
 local autoPilot = nil
+local hasPaid = nil
+local InTaxi = false
+local IsTaxiDriving = false
+local InHurryMode = false
 
 local function IsVehicleValid(vehicleModel)
 	local retval = false
@@ -15,70 +19,229 @@ local function IsVehicleValid(vehicleModel)
 	return retval
 end
 
-RegisterNetEvent('md-aitaxi:client:payCheck', function()
-	if ordered == nil then
-		TriggerServerEvent('md-aitaxi:server:PayForTaxi')
-		ordered = true
-	else
-		QBCore.Functions.Notify('Already Called A Taxi')
-	end
-end)
+local function CalculateRouteDistance(wayPointBlip, waypointCoords)
+    SetBlipRoute(wayPointBlip, true)
+    
+    Wait(500) 
+
+    local routeLengthMeters = GetGpsBlipRouteLength()
+    print(tostring(routeLengthMeters))
+
+    local routeLengthKilometers = routeLengthMeters / 1000.0
+
+    TriggerServerEvent('md-aitaxi:server:CanAffordTaxi', routeLengthKilometers)
+end
 
 RegisterNetEvent('md-aitaxi:client:calltaxi', function()
-	local pedCoord = GetEntityCoords(cache.ped)
-	local taxiDriver = config.DriverPed
-	if ordered then
-		lib.requestModel(taxiDriver, 500)
-		lib.requestModel(`taxi`, 500)
-		local aiTaxi = CreateVehicle(`taxi`, pedCoord.x + 5, pedCoord.y + 5, pedCoord.z - 1, 180.0, true, true)
-		local taxi = CreatePed(26, joaat(taxiDriver), pedCoord.x + 5, pedCoord.y + 5, pedCoord.z - 1, 268.9422, true, false)
-		SetVehicleOnGroundProperly(aiTaxi)
-		SetEntityAsMissionEntity(aiTaxi)
-		taxiblip = AddBlipForEntity(aiTaxi)
-		SetPedIntoVehicle(taxi, aiTaxi, -1)
-		exports[config.Fuel]:SetFuel(aiTaxi, 100.0)
-		TaskVehicleDriveToCoordLongrange(taxi, aiTaxi, pedCoord.x + 2, pedCoord.y - 1, pedCoord.z - 1, 50.0, 60, 1.0)
-		Wait(1000)
-		local loc = #(GetEntityCoords(cache.ped) - GetEntityCoords(aiTaxi))
-		Wait(2000)
-		if loc < 10.0 then
-			SetPedIntoVehicle(cache.ped, aiTaxi, 0)
-			QBCore.Functions.Notify('Set A Way Point So I Know Where To Go')
-		end
-		repeat
-			Wait(1000)
-		until GetFirstBlipInfoId(8) ~= 0
-		if GetVehiclePedIsIn(cache.ped) == aiTaxi then
-			local wayPointBlip = GetFirstBlipInfoId(8)
-			local coord = Citizen.InvokeNative(0xFA7C7F0AADF25D09, wayPointBlip, Citizen.ResultAsVector())
-			TaskVehicleDriveToCoordLongrange(taxi, aiTaxi, coord.x, coord.y, coord.z - 1, 30.0, 319, 5.0)
-			SetVehicleMaxSpeed(aiTaxi, 60.00)
-			repeat
-				local loc2 = #(GetEntityCoords(aiTaxi) - coord)
-				Wait(1000)
-			until loc2 < 50.0
-			Wait(2000)
-			TaskLeaveVehicle(cache.ped, aiTaxi, 0)
-			Wait(1000)
-			TaskVehicleDriveWander(taxi, aiTaxi, 50.0, 60)
-			ordered = nil
-			RemoveBlip(taxiblip)
-			Wait(5000)
-			DeleteVehicle(aiTaxi)
-			DeleteEntity(taxi)
-		else
-			QBCore.Functions.Notify('You Left The Vehicle')
-		end
+	ordered = true
+    local pedCoord = GetEntityCoords(cache.ped)
+    local taxiDriver = config.DriverPeds[math.random(1,#config.DriverPeds)]
+	ExecuteCommand('e c')
+    local streetCoord = vector3(0.0, 0.0, 0.0)
+
+    local nodeFound, nodeCoord = GetRandomVehicleNode(pedCoord.x, pedCoord.y, pedCoord.z, 100.0, true, true, true, streetCoord, 1)
+
+    if nodeFound then
+        if ordered then
+            lib.requestModel(taxiDriver, 500)
+            lib.requestModel(config.TaxiModel, 500)
+            
+            local aiTaxi = CreateVehicle(config.TaxiModel, nodeCoord.x, nodeCoord.y, nodeCoord.z, 180.0, true, true)
+            local taxi = CreatePed(26, joaat(taxiDriver), nodeCoord.x, nodeCoord.y, nodeCoord.z, 268.9422, true, false)
+
+            SetVehicleOnGroundProperly(aiTaxi)
+            SetEntityAsMissionEntity(aiTaxi)
+            taxiblip = AddBlipForEntity(aiTaxi)
+			SetBlipSprite(taxiblip, 198)
+			SetBlipScale(taxiblip, 0.5)
+			SetBlipColour(taxiblip, 5)
+            SetPedIntoVehicle(taxi, aiTaxi, -1)
+            exports[config.Fuel]:SetFuel(aiTaxi, 100.0)
+
+            TaskVehicleDriveToCoordLongrange(taxi, aiTaxi, pedCoord.x, pedCoord.y, pedCoord.z, 50.0, 447, 1.0)
+            Wait(1000)
+			
+            CreateThread(function()
+                while not InTaxi do
+                    local loc = #(GetEntityCoords(cache.ped) - GetEntityCoords(aiTaxi))
+                    Wait(100)
+                    
+                    if loc < 10.0 then
+                        TaskVehicleTempAction(taxi, aiTaxi, 1, 1)
+						local seat = math.random(1,2)
+						TaskEnterVehicle(cache.ped,aiTaxi, 5000, seat, 1.0, 1, 0)
+						Wait(5000)
+                        QBCore.Functions.Notify('Set A Way Point So I Know Where To Go')
+                        InTaxi = true
+                    end
+                end
+            end)
+
+            repeat
+                Wait(1000)
+            until InTaxi
+
+            repeat
+                Wait(1000)
+            until GetFirstBlipInfoId(8) ~= 0
+
+            if GetVehiclePedIsIn(cache.ped) == aiTaxi then
+                local wayPointBlip = GetFirstBlipInfoId(8)
+                local waypointCoords = GetBlipInfoIdCoord(8)
+                CalculateRouteDistance(wayPointBlip, waypointCoords)
+
+                repeat
+                    Wait(1000)
+                until hasPaid ~= nil
+
+                if hasPaid then
+                    if GetVehiclePedIsIn(cache.ped) == aiTaxi then
+                        local coord = Citizen.InvokeNative(0xFA7C7F0AADF25D09, wayPointBlip, Citizen.ResultAsVector())
+                        IsTaxiDriving = true
+						local stresstick = 0
+						InHurryMode = false
+						local hurrying = false
+						local hurrylabelshown = false
+                        
+                        CreateThread(function()
+                            while IsTaxiDriving do
+                                local currentCoord = GetEntityCoords(aiTaxi)
+                                local distanceToDestination = #(currentCoord - coord)
+                                
+                                if distanceToDestination < 50.0 then
+                                    TaskVehiclePark(taxi, aiTaxi, coord.x, coord.y, coord.z, GetEntityHeading(aiTaxi), 1, 5.0, true)
+                                    IsTaxiDriving = false
+                                end
+								stresstick = stresstick + 1
+								if stresstick >= 120 then
+									if config.TaxiRelievesStress and config.TaxiRelievesStress > 0 then
+										TriggerServerEvent('hud:server:RelieveStress', config.TaxiRelievesStress)
+										stresstick = 0
+									end
+								end
+                                Wait(500)
+                            end
+                        end)
+
+						CreateThread(function()
+                            while IsTaxiDriving do
+								if config.AllowHurryMode then
+									if not InHurryMode then
+										if not hurrylabelshown then
+											local label = "[E] Hurry $"..config.HurryTip
+											exports['qb-core']:DrawText(label, 'right')
+											hurrylabelshown = true
+										end
+                                		if IsControlJustPressed(0,38) then
+											TriggerServerEvent('md-aitaxi:server:PayHurryCost')
+										end
+									end
+									if InHurryMode and not hurrying then
+										exports['qb-core']:HideText()
+										TaskVehicleDriveToCoordLongrange(taxi, aiTaxi, coord.x, coord.y, coord.z - 1, 120.0, 787004, 5.0)
+										SetVehicleMaxSpeed(aiTaxi, 120.00)
+										QBCore.Functions.Notify('OK Ill Get There Fast')
+										hurrying = true
+									end
+								end
+                                Wait(0)
+                            end
+                        end)
+                        
+                        TaskVehicleDriveToCoordLongrange(taxi, aiTaxi, coord.x, coord.y, coord.z - 1, 30.0, 447, 5.0)
+                        SetVehicleMaxSpeed(aiTaxi, 60.00)
+                        
+                        repeat
+                            Wait(1000)
+                        until not IsTaxiDriving
+                        
+                        TaskLeaveVehicle(cache.ped, aiTaxi, 0)
+                        Wait(1000)
+                        TaskVehicleDriveWander(taxi, aiTaxi, 50.0, 60)
+                        ordered = nil
+                        hasPaid = nil
+                        InTaxi = false
+						IsTaxiDriving = false
+						InHurryMode = false
+						exports['qb-core']:HideText()
+                        RemoveBlip(taxiblip)
+                        Wait(5000)
+                        DeleteVehicle(aiTaxi)
+                        DeleteEntity(taxi)
+                    else
+                        QBCore.Functions.Notify('You Left The Vehicle')
+                    end
+                else
+                    TaskLeaveVehicle(cache.ped, aiTaxi, 0)
+                    Wait(1000)
+                    TaskVehicleDriveWander(taxi, aiTaxi, 50.0, 60)
+                    ordered = nil
+                    hasPaid = nil
+                    InTaxi = false
+					IsTaxiDriving = false
+					InHurryMode = false
+					exports['qb-core']:HideText()
+                    RemoveBlip(taxiblip)
+                    Wait(5000)
+                    DeleteVehicle(aiTaxi)
+                    DeleteEntity(taxi)
+                end
+            else
+                QBCore.Functions.Notify('You Left The Vehicle')
+            end
+        end
+    else
+        QBCore.Functions.Notify('No Suitable Road Found Nearby')
+		ordered = nil
+    end
+end)
+
+
+RegisterNetEvent('md-aitaxi:client:hasPaid',function(bool,amount)
+	if bool then
+		QBCore.Functions.Notify("You Paid $"..amount)
+	else
+		QBCore.Functions.Notify("You Dont Have $"..amount)
 	end
+	hasPaid = bool
+end)
+
+RegisterNetEvent('md-aitaxi:client:HurryPaid',function(bool,amount)
+	if not bool then
+		QBCore.Functions.Notify("You Dont Have $"..amount)
+	end
+	InHurryMode = bool
 end)
 
 RegisterCommand(config.TaxiCommand, function()
 	if ordered == nil then
-		QBCore.Functions.Notify('Calling A Taxi')
-		Wait(7000)
-		TriggerEvent('md-aitaxi:client:payCheck')
+		if Config.RequirePhoneItem then
+			for k,v in pairs(Config.Phones) do
+				if QBCore.Functions.HasItem(v) then
+					hasphone = true
+					break
+				end
+			end
+			if hasphone then
+				ExecuteCommand('e phonecall')
+				QBCore.Functions.Notify('Calling A Taxi')
+				Wait(7000)
+				TriggerEvent('md-aitaxi:client:calltaxi')
+			else
+				QBCore.Functions.Notify('You Need a Phone')
+			end
+		else
+			ExecuteCommand('e phonecall')
+			QBCore.Functions.Notify('Calling A Taxi')
+			Wait(7000)
+			TriggerEvent('md-aitaxi:client:calltaxi')
+		end
 	else
-		QBCore.Functions.Notify('Already Have A Taxi')
+		if not IsTaxiDriving then
+			QBCore.Functions.Notify('Youre Taxi Is En Route!')
+		else
+			QBCore.Functions.Notify('Already In A Taxi')
+		end
 	end
 end)
 
@@ -131,7 +294,7 @@ RegisterCommand(config.TaxiStopCommand, function()
 	ClearPedTasks(cache.ped)
 	ClearVehicleTasks(GetVehiclePedIsIn(cache.ped, true))
 	local vehicle = GetVehiclePedIsIn(cache.ped, true)
-	if GetEntityModel(vehicle) == `taxi` then
+	if GetEntityModel(vehicle) == config.TaxiModel then
 		DeleteVehicle(GetVehiclePedIsIn(cache.ped, true))
 	end
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,12 +1,29 @@
 Config = {}
- 
-Config.Price = 1000 -- Price for the taxi
-Config.DriverPed = "ig_priest" -- Ped You Want To be Driving
+
+Config.TaxiModel = `taxi`
+Config.PricePerKM = 50 -- Price for the taxi per KM
+Config.HurryTip = 50 --amount to pay to make driver go faster
 Config.TaxiCommand = "aitaxi" -- command to start taxi ride
 Config.TaxiStopCommand = 'stoptaxi'
 Config.AutopilotCommand = "autopilot"
 Config.AutopilotstopCommand = "autopilotstop"
 Config.Fuel = "LegacyFuel" -- name of the resource you use for fuel
+
+Config.AllowHurryMode = true -- press E when in taxi to pay for fast mode
+Config.TaxiRelievesStress = 3 --relieves this much stress every minute in a taxi // or false for no stress relief
+Config.RequirePhoneItem = true --means you need a phone to be able to use taxi command
+Config.Phones = { --the phone item codes
+    'phone',
+    'black_phone',
+    'pink_phone',
+    'blue_phone',
+    'red_phone',
+    'classic_phone',
+    'gold_phone',
+    'greenlight_phone',
+    'green_phone',
+    'white_phone',
+}
 
 Config.AutoPilotCars = {
     'buffalo5', -- Buffalo evx (Newest gamebuild only(2944))
@@ -24,3 +41,21 @@ Config.AutoPilotCars = {
     'dilettante',
 }
 
+Config.DriverPeds = { --taxi driver peds
+    'ig_priest',
+    'a_m_m_eastsa_01',
+    'a_m_m_genfat_02',
+    'a_m_m_polynesian_01',
+    'a_m_m_socenlat_01',
+    'a_m_o_genstreet_01',
+    'a_m_y_bevhills_01',
+    'a_m_y_business_02',
+    'a_m_y_hipster_02',
+    'a_m_y_soucent_02',
+    'a_f_m_prolhost_01',
+    'a_f_m_tourist_01',
+    'a_f_o_genstreet_01',
+    'a_f_o_soucent_01',
+    'a_f_y_eastsa_03',
+    'a_f_y_vinewood_01',
+}

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,11 +1,34 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local config = Config
 
-RegisterServerEvent('md-aitaxi:server:PayForTaxi', function()
-	local src = source
-	local Player = QBCore.Functions.GetPlayer(src)
+RegisterServerEvent('md-aitaxi:server:CanAffordTaxi', function(distance)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    local payment = math.floor(distance * config.PricePerKM)
+    
+    if Player.Functions.GetMoney('cash') >= payment then
+        Player.Functions.RemoveMoney('cash', payment)
+        TriggerClientEvent('md-aitaxi:client:hasPaid', src, true, payment)
+    elseif Player.Functions.GetMoney('bank') >= payment then
+        Player.Functions.RemoveMoney('bank', payment)
+        TriggerClientEvent('md-aitaxi:client:hasPaid', src, true, payment)
+    else
+        TriggerClientEvent('md-aitaxi:client:hasPaid', src, false, payment)
+    end
+end)
 
-	if Player.Functions.RemoveMoney('cash', config.Price) or Player.Functions.RemoveMoney('bank', config.Price) then
-		TriggerClientEvent('md-aitaxi:client:calltaxi', src)
-	end
+RegisterServerEvent('md-aitaxi:server:PayHurryCost', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+	local payment = Config.HurryTip
+    
+    if Player.Functions.GetMoney('cash') >= payment then
+        Player.Functions.RemoveMoney('cash', payment)
+        TriggerClientEvent('md-aitaxi:client:HurryPaid', src, true, payment)
+    elseif Player.Functions.GetMoney('bank') >= payment then
+        Player.Functions.RemoveMoney('bank', payment)
+        TriggerClientEvent('md-aitaxi:client:HurryPaid', src, true, payment)
+    else
+        TriggerClientEvent('md-aitaxi:client:HurryPaid', src, false, payment)
+    end
 end)


### PR DESCRIPTION
taxi driving now more RP friendly
hurry mode available for a tip
optional taxi stress relief every minute
taxi now parks up and player walks into taxi (5 second timeout then player teleports in to handle any issues) same with leaving taxi, parks up and you walk out.  option to require a phone item to call taxi
taxi price works by distance per KM
executes command for emote when calling taxi
picks a random driver from a config table
taxi now spawns within 100 radius of player on a valid vehicle node(on the road) taxi blip is now a small yellow taxi